### PR TITLE
Fix tests TP2

### DIFF
--- a/TPs/tests/TP2.tests/src/tp2/tests/RechercheDichotomiqueIterativeTest.java
+++ b/TPs/tests/TP2.tests/src/tp2/tests/RechercheDichotomiqueIterativeTest.java
@@ -24,7 +24,7 @@ public class RechercheDichotomiqueIterativeTest {
 
 	@Test
 	public void testCherche() {
-		int [] tab = new RechercheTableauxTest().generateTab(100, 1000, -10000, 10000);
+		int [] tab = new RechercheTableauxTest().generateTab(100, 1000, -100, 100);
 
 		RechercheDichotomiqueIterative r = new RechercheDichotomiqueIterative(tab);
 		assertEquals(-1, r.findN(200));
@@ -41,7 +41,7 @@ public class RechercheDichotomiqueIterativeTest {
 		Complexity.LOG = false;
 		double v = Complexity.evalLog(
 				taille -> {	
-					int [] tab = new RechercheTableauxTest().generateTab(taille, taille, -10000, 10000);
+					int [] tab = new RechercheTableauxTest().generateTab(taille, taille, -100, 100);
 					return new RechercheDichotomiqueIterative(tab);
 				}, 
 				r -> { r.findN(200); }, 

--- a/TPs/tests/TP2.tests/src/tp2/tests/RechercheTableauxTest.java
+++ b/TPs/tests/TP2.tests/src/tp2/tests/RechercheTableauxTest.java
@@ -28,7 +28,7 @@ public class RechercheTableauxTest {
 
 	@Test
 	public void testFindNinT() {
-		int [] tab = generateTab(100, 1000, -10000, 10000);
+		int [] tab = generateTab(100, 1000, -100, 100);
 
 		assertEquals(-1, RechercheTableaux.findNinT(tab, 200));
 
@@ -72,7 +72,7 @@ public class RechercheTableauxTest {
 
 	@Test
 	public void testFindNinSortedT() {
-		int [] tab = generateTab(100, 1000, -10000, 10000);
+		int [] tab = generateTab(100, 1000, -100, 100);
 		Arrays.sort(tab);
 		assertEquals(-1, RechercheTableaux.findNinSortedT(tab, 200));
 
@@ -108,9 +108,9 @@ public class RechercheTableauxTest {
 		double v = Complexity.eval(
 				taille -> {	return generateTab(taille, taille, -10000, 10000); }, 
 				tab -> { RechercheTableaux.findNinT(tab, 100000); }, 
-				5, 10); // 10^5 -> 10^10
+				4, 9); // 10^4 -> 10^9
 		System.out.println("\t-> t(N)=N^" + v);
-		assertEquals(1.0, v, 0.1); // Expect a linear complexity
+		assertEquals(1.0, v, 0.2); // Expect a linear complexity
 	}
 	
 


### PR DESCRIPTION
J'ai changé la génération des tableaux pour s'assurer que l'élément cherché ne peut pas y être, et j'ai baissé légérement la taille max des tableaux générés, pour éviter des bugs OutOfMemory sur les machines de élèves.