### PR TITLE
Fix tests recherche

### DIFF
--- a/TPs/tests/TP2.tests/src/tp2/tests/RechercheDichotomiqueIterativeTest.java
+++ b/TPs/tests/TP2.tests/src/tp2/tests/RechercheDichotomiqueIterativeTest.java
@@ -1,6 +1,7 @@
 package tp2.tests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Random;
@@ -28,10 +29,12 @@ public class RechercheDichotomiqueIterativeTest {
 
 		RechercheDichotomiqueIterative r = new RechercheDichotomiqueIterative(tab);
 		assertEquals(-1, r.findN(200));
+		assertEquals(-1, r.findN(-200));
 
 		int pos = generateur.nextInt(tab.length);
 		int ind = r.findN(r.get(pos));
-		assertTrue(ind + ":" + pos, ind <= pos);
+		assertNotEquals("L'élément n'a pas été trouvé", ind, -1);
+		assertEquals(r.get(ind), r.get(pos));
 	}
 
 
@@ -41,7 +44,7 @@ public class RechercheDichotomiqueIterativeTest {
 		Complexity.LOG = false;
 		double v = Complexity.evalLog(
 				taille -> {	
-					int [] tab = new RechercheTableauxTest().generateTab(taille, taille, -100, 100);
+					int [] tab = new RechercheTableauxTest().generateTab(taille, taille, -10000, 10000);
 					return new RechercheDichotomiqueIterative(tab);
 				}, 
 				r -> { r.findN(200); }, 

--- a/TPs/tests/TP2.tests/src/tp2/tests/RechercheSequentielleTest.java
+++ b/TPs/tests/TP2.tests/src/tp2/tests/RechercheSequentielleTest.java
@@ -1,6 +1,7 @@
 package tp2.tests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Random;
@@ -31,7 +32,8 @@ public class RechercheSequentielleTest {
 
 		int pos = generateur.nextInt(tab.length);
 		int ind = r.findN(tab[pos]);
-		assertTrue(ind <= pos);
+		assertNotEquals("L'élément n'a pas été trouvé", ind, -1);
+		assertEquals(tab[ind], tab[pos]);
 	}
 
 	@Test
@@ -76,7 +78,7 @@ public class RechercheSequentielleTest {
 					return new RechercheSequentielle(tab);
 				}, 
 				r -> { r.findN(20000); }, 
-				5, 10); // 10^5 -> 10^10
+				5, 9); // 10^5 -> 10^9
 		System.out.println("\t-> t(N)=N^" + v);
 		assertEquals(1.0, v, 0.16); // Expect a linear complexity
 	}
@@ -92,8 +94,8 @@ public class RechercheSequentielleTest {
 					return new RechercheSequentielle(tab);
 				}, 
 				r -> { r.countNs(42); }, 
-				5, 10); // 10^5 -> 10^10
+				5, 9); // 10^5 -> 10^9
 		System.out.println("\t-> t(N)=N^" + v);
-		assertEquals(1.0, v, 0.16); // Expect a linear complexity
+		assertEquals(1.0, v, 0.3); // Expect a linear complexity
 	}
 }

--- a/TPs/tests/TP2.tests/src/tp2/tests/RechercheTableauxTest.java
+++ b/TPs/tests/TP2.tests/src/tp2/tests/RechercheTableauxTest.java
@@ -34,11 +34,13 @@ public class RechercheTableauxTest {
 
 		int pos = generateur.nextInt(tab.length);
 		int ind = RechercheTableaux.findNinT(tab, tab[pos]);
-		assertTrue(ind <= pos);		
+		assertNotEquals("L'élément n'a pas été trouvé", ind, -1);
+		assertEquals(tab[ind], tab[pos]);
 
 		tab[pos] = 42;
 		int p = RechercheTableaux.findNinT(tab, 42);
-		assertTrue(p <= pos);
+		assertNotEquals("L'élément n'a pas été trouvé", p, -1);
+		assertEquals(tab[p], tab[pos]);
 	}
 
 	@Test
@@ -78,12 +80,13 @@ public class RechercheTableauxTest {
 
 		int pos = generateur.nextInt(tab.length);
 		int ind = RechercheTableaux.findNinSortedT(tab, tab[pos]);
+		assertNotEquals("L'élément n'a pas été trouvé", ind, -1);
 		assertEquals(tab[ind], tab[pos]);		
 
 		tab[pos] = 42;
 		Arrays.sort(tab);
 		int p = RechercheTableaux.findNinSortedT(tab, 42);
-		assertNotEquals(-1, p);
+		assertNotEquals("L'élément n'a pas été trouvé", -1, p);
 	}
 
 	@Test
@@ -110,7 +113,7 @@ public class RechercheTableauxTest {
 				tab -> { RechercheTableaux.findNinT(tab, 100000); }, 
 				4, 9); // 10^4 -> 10^9
 		System.out.println("\t-> t(N)=N^" + v);
-		assertEquals(1.0, v, 0.2); // Expect a linear complexity
+		assertEquals(1.0, v, 0.3); // Expect a linear complexity
 	}
 	
 
@@ -123,6 +126,6 @@ public class RechercheTableauxTest {
 				tab -> { RechercheTableaux.countNsinT(tab, 42); }, 
 				4, 9); // 10^4 -> 10^9
 		System.out.println("\t-> t(N)=N^" + v);
-		assertTrue(v < 1.1); // Expect a linear complexity (tolerates 10%
+		assertTrue(v < 1.15); // Expect a linear complexity (tolerates 15%
 	}
 }


### PR DESCRIPTION
Bonjour Frederic,

J'ai remarqué un bug potentiel dans les tests de recherche, notamment pour la recherche dichotomique, dans les cas où le tableau contiendrait plus d'une fois l'élément recherché, le test pouvait ne pas passer pour un algo correct. J'ai transformé les tests sur les indices eg `ind <= pos` en tests sur les valeurs eg `tab[ind] == tab[pos]`.

J'ai aussi rendu les tests de complexité un peu moins lourd en mémoire et plus permissifs car on a remarqué des problèmes avec plusieurs élèves.